### PR TITLE
Renames es namespace to storage, fixed some typos

### DIFF
--- a/src/scio_back/doc.clj
+++ b/src/scio_back/doc.clj
@@ -2,7 +2,7 @@
   (:import [info.debatty.java.spamsum SpamSum])
   (:require
    [scio-back.tag :as tag]
-   [scio-back.es :as es]
+   [scio-back.storage :as storage]
    [pantomime.extract :as extract]
    [scio-back.nlp :as nlp]
    [scio-back.scraper :as scraper]
@@ -145,7 +145,7 @@
           (if-let [a (with-timeout ms-running-time sha256
                        (analyse file-name cfg sha256))]
             (do
-              (es/send-to-nifi
+              (storage/send-to-nifi
                (into a record)
                cfg
                (str (get-in cfg [:storage :index]) "/doc")

--- a/src/scio_back/storage.clj
+++ b/src/scio_back/storage.clj
@@ -1,10 +1,10 @@
-(ns scio-back.es
+(ns scio-back.storage
     (:require
      [clj-http.client :as client]
      [clojure.data.json :as json]))
 
 (defn send-to-elasticsearch
-  "Send a datastructure to elasticsearch"
+  "Send a data structure to Elasticsearch"
   [data cfg doc-type sha-256]
   (let [document (json/write-str data)
         host (:elasticsearch (:storage cfg))
@@ -15,8 +15,8 @@
                   :accept :json})))
 
 (defn send-to-nifi
-  "Send a datastructure to nifi"
-  [data cfg _ sha-256]
+  "Send a data structure to NiFi"
+  [data cfg _ _]
   (let [document (json/write-str data)
         url (get-in cfg [:storage :nifi])]
     (client/post url


### PR DESCRIPTION
There was a namespace called es in the project. It seemed to contain both sending of data structures to Elasticsearch and NiFi (and could be expanded in the future). So i renamed it to "storage". In the future if any other forms of output (dump to file, send to beanstalkd, etc) are added this namespace could contain all these capabilities.