### PR TITLE
remove exit from get-vendor-files that was used while testing

### DIFF
--- a/scripts/get-vendor-files.sh
+++ b/scripts/get-vendor-files.sh
@@ -20,8 +20,6 @@ unzip -o $GEO_HOME/cities15000.zip cities15000.txt -d $GEO_HOME
 curl http://download.geonames.org/export/dump/countryInfo.txt -o $GEO_HOME/countryInfo.txt
 sed -i '/^#/d' $GEO_HOME/countryInfo.txt
 
-exit 1
-
 # Remove downloaded zip files
 rm -f $GEO_HOME/cities1*zip
 


### PR DESCRIPTION
Remove `exit` that was unintentionally left in get-vendor-files.sh while testing.