### PR TITLE
Tlds check and dedefang http

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject scio-back "0.1.41-SNAPSHOT"
+(defproject scio-back "0.1.42-SNAPSHOT"
   :description "Storing tweets and documents to alastic search for indexing."
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [org.apache.commons/commons-compress "1.18"] ;; "fix" for missing class in pantomime

--- a/src/scio_back/scraper.clj
+++ b/src/scio_back/scraper.clj
@@ -71,10 +71,18 @@
 
 (def not-nil? (complement nil?))
 
+(defn remove-from-end [s end]
+  """remove [end] from the end of [s]"""
+  (if (.endsWith s end)
+    (.substring s 0 (- (count s)
+                       (count end)))
+    s))
+
 (defn- ends-in-tld?
   "check if the string end in .[a-z]{2,} (two or more lowercase characters)"
   [tlds text]
-  (let [found (map #(re-find (tld-pattern %) text) tlds)]
+  (let [text (remove-from-end text ".")
+        found (map #(re-find (tld-pattern %) text) tlds)]
     (some not-nil? found)))
 
 (defn tlds-from-files
@@ -93,6 +101,7 @@
   (let [config-files (string/split (get-in cfg [:scraper :tld]) #",")
         tlds (tlds-from-files config-files)
         soft-text (-> (.toLowerCase text)
+                      (clojure.string/replace "hxxp" "http")
                       (clojure.string/replace "[.]" ".")
                       (clojure.string/replace "(.)" ".")
                       (clojure.string/replace "{.}" ".")

--- a/src/scio_back/scraper.clj
+++ b/src/scio_back/scraper.clj
@@ -120,4 +120,4 @@
      :ipv4net (raw-text->ipv4net soft-text)
      :ipv6 (filter validator/ipv6-form? (raw-text->ipv6 soft-text))
      :uri (raw-text->uri soft-text)
-     :fqdn (filter (partial ends-in-tld? tlds) (raw-text->fqdn soft-text))}))
+     :fqdn (map #(remove-from-end % ".") (filter (partial ends-in-tld? tlds) (raw-text->fqdn soft-text)))}))

--- a/src/scio_back/scraper.clj
+++ b/src/scio_back/scraper.clj
@@ -32,7 +32,11 @@
 (defn raw-text->uri
   "Extract all uri from a raw text"
   [text]
-  (map #(get % 0) (re-seq uri-re-string text)))
+  (let [first-extract (map #(get % 0) (re-seq uri-re-string text))
+        ;; refang hxxp -> http
+        res (map #(clojure.string/replace % (re-pattern #"(?i)^hxxp") "http") first-extract)]
+    res))
+
 
 (def ip-re-string #"([a-zA-Z]*:\/\/)?\b([0-2]?[0-9]?[0-9]\.[0-2]?[0-9]?[0-9]\.[0-2]?[0-9]?[0-9]\.[0-2]?[0-9]?[0-9])(\/\d{1,2})?\b")
 
@@ -101,7 +105,6 @@
   (let [config-files (string/split (get-in cfg [:scraper :tld]) #",")
         tlds (tlds-from-files config-files)
         soft-text (-> (.toLowerCase text)
-                      (clojure.string/replace "hxxp" "http")
                       (clojure.string/replace "[.]" ".")
                       (clojure.string/replace "(.)" ".")
                       (clojure.string/replace "{.}" ".")

--- a/test/scio_back/scraper_test.clj
+++ b/test/scio_back/scraper_test.clj
@@ -66,7 +66,7 @@
       (is (= (:ipv4net indicators) '("5.6.7.8/9" "6.7.8.9/10"))))
 
     (testing "scrape fqdn lowercase"
-      (is  (= (:fqdn indicators) '("my.test.no" "chessbase.com" "chessbase.com" "twitter.com" "twitter.com" "twitter.com" "files.example.com" "www.vg.no" "www.nytimes3xbfgragh.onion" "fastmail.fm" "www.mnemonic.no" "this.ends.in.tld.no."))))
+      (is  (= (:fqdn indicators) '("my.test.no" "chessbase.com" "chessbase.com" "twitter.com" "twitter.com" "twitter.com" "files.example.com" "www.vg.no" "www.nytimes3xbfgragh.onion" "fastmail.fm" "www.mnemonic.no" "this.ends.in.tld.no"))))
 
     (testing "scrape ipv6 lowercase"
       (is  (= (:ipv6 indicators) '("fe80::ea39:35ff:fe12:2d71"))))

--- a/test/scio_back/scraper_test.clj
+++ b/test/scio_back/scraper_test.clj
@@ -19,8 +19,8 @@
     ftp://files.example.com lorem ipsum
     https://www.vg.no/index.html?q=news#top lorem / ipsum
     HTTP://1.2.3.4/5-index.html / lorem ipsum
-    http://2.3.4.5/ lorem / ipsum
-    http://3.4.5.6 lorem ipsum
+    hXXp://2.3.4.5/ lorem / ipsum
+    hxxps://3.4.5.6 lorem ipsum
     4.5.6.7/gurba lorem ipsum
     5.6.7.8/9 lorem ipsum
     6.7.8.9/10 lorem ipsum
@@ -32,7 +32,8 @@
     www.nytimes3xbfgragh.onion lorem ipsum
     fe80::ea39:35ff:fe12:2d71/64 lorem ipsum
     The mail address user@fastmail.fm is not real
-    www.mnemonic.no")
+    www.mnemonic.no
+    this.ends.in.tld.no.")
 
 (def test-text-uppercase
   (clojure.string/upper-case test-text-lowercase))
@@ -65,13 +66,13 @@
       (is (= (:ipv4net indicators) '("5.6.7.8/9" "6.7.8.9/10"))))
 
     (testing "scrape fqdn lowercase"
-      (is  (= (:fqdn indicators) '("chessbase.com" "chessbase.com" "twitter.com" "twitter.com" "twitter.com" "files.example.com" "www.vg.no" "www.nytimes3xbfgragh.onion" "fastmail.fm" "www.mnemonic.no"))))
+      (is  (= (:fqdn indicators) '("chessbase.com" "chessbase.com" "twitter.com" "twitter.com" "twitter.com" "files.example.com" "www.vg.no" "www.nytimes3xbfgragh.onion" "fastmail.fm" "www.mnemonic.no" "this.ends.in.tld.no."))))
 
     (testing "scrape ipv6 lowercase"
       (is  (= (:ipv6 indicators) '("fe80::ea39:35ff:fe12:2d71"))))
 
     (testing "scrape uri"
-      (is (= (:uri indicators) '("ftp://files.example.com" "https://www.vg.no/index.html?q=news#top" "http://1.2.3.4/5-index.html" "http://2.3.4.5/" "http://3.4.5.6"))))
+      (is (= (:uri indicators) '("ftp://files.example.com" "https://www.vg.no/index.html?q=news#top" "http://1.2.3.4/5-index.html" "http://2.3.4.5/" "https://3.4.5.6"))))
 
     (testing "scrape cve lowercase"
       (is (= (:cve indicators) '("cve-1991-1234" "cve-1992-12345" "cve-1993-123456" "cve-1994-1234567"))))))

--- a/test/scio_back/scraper_test.clj
+++ b/test/scio_back/scraper_test.clj
@@ -3,7 +3,7 @@
             [scio-back.scraper :refer :all]
             [scio-back.core :refer [read-config]]))
 
-(def test-text-lowercase "
+  (def test-text-lowercase "hXXp://my.test.no/hxxp/
     md5: be5ee729563fa379e71d82d61cc3fdcf lorem ipsum
     sha256: 103cb6c404ba43527c2deac40fbe984f7d72f0b2366c0b6af01bd0b4f1a30c74 lorem ipsum
     sha1: 3c07cb361e053668b4686de6511d6a904a9c4495 lorem ipsum
@@ -66,13 +66,13 @@
       (is (= (:ipv4net indicators) '("5.6.7.8/9" "6.7.8.9/10"))))
 
     (testing "scrape fqdn lowercase"
-      (is  (= (:fqdn indicators) '("chessbase.com" "chessbase.com" "twitter.com" "twitter.com" "twitter.com" "files.example.com" "www.vg.no" "www.nytimes3xbfgragh.onion" "fastmail.fm" "www.mnemonic.no" "this.ends.in.tld.no."))))
+      (is  (= (:fqdn indicators) '("my.test.no" "chessbase.com" "chessbase.com" "twitter.com" "twitter.com" "twitter.com" "files.example.com" "www.vg.no" "www.nytimes3xbfgragh.onion" "fastmail.fm" "www.mnemonic.no" "this.ends.in.tld.no."))))
 
     (testing "scrape ipv6 lowercase"
       (is  (= (:ipv6 indicators) '("fe80::ea39:35ff:fe12:2d71"))))
 
     (testing "scrape uri"
-      (is (= (:uri indicators) '("ftp://files.example.com" "https://www.vg.no/index.html?q=news#top" "http://1.2.3.4/5-index.html" "http://2.3.4.5/" "https://3.4.5.6"))))
+      (is (= (:uri indicators) '("http://my.test.no/hxxp/" "ftp://files.example.com" "https://www.vg.no/index.html?q=news#top" "http://1.2.3.4/5-index.html" "http://2.3.4.5/" "https://3.4.5.6"))))
 
     (testing "scrape cve lowercase"
       (is (= (:cve indicators) '("cve-1991-1234" "cve-1992-12345" "cve-1993-123456" "cve-1994-1234567"))))))

--- a/test/scio_back/tag_test.clj
+++ b/test/scio_back/tag_test.clj
@@ -41,7 +41,8 @@
 
 (deftest region-test
   (testing "Check that we can filter out valid regions and sub-regions"
-    (let [region-cfg "vendor/geonames/ISO-3166-countries-with-regional-codes.json"]
+    (let [cfg (read-config "etc/scio.ini.local")
+          region-cfg (get-in cfg [:geonames :regions])]
       (is (= (country->region region-cfg #{"Norway", "Unknown", "Japan"}, :region) #{"Asia", "Europe"}))
       (is (= (country->region region-cfg #{"Norway", "Unknown", "Japan"}, :sub-region) #{"Northern Europe", "Eastern Asia"})))))
 


### PR DESCRIPTION
Fixed BUG: FQDN at the end of a sentance would not be detected due to
ending '.' Stripping '.' from the end of potensial FQDN before checking
valid TLD

Improvement: De-defanging uris` with hXXp

Improvement: Testing regions now properly gets location of region .json
from local test .ini