### PR TITLE
Post metadata to Scio

### DIFF
--- a/scripts/feeds/upload.py
+++ b/scripts/feeds/upload.py
@@ -258,9 +258,10 @@ def main(args):
             if candidate.uploadable():
                 with open(candidate.filename, "rb") as file_h:
                     post_data = to_scio_submit_post_data(file_h, candidate.filename)
+                    my_metadata.update(post_data)
                     session = requests.Session()
                     session.trust_env = False
-                    session.post(args.scio, json=post_data)
+                    session.post(args.scio, json=my_metadata)
             else:
                 LOGGER.info("Not uploading %s (wrong mimetype)", candidate.filename) # NOQA
 


### PR DESCRIPTION
The .meta files that contains the link/links and creation-date etc. has
not been used after the submit changed from a local post to a work queue
to using the API.

This patch restores posting of the metadata to the work queue of Scio.