### PR TITLE
Bugfix and doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ mkdir -p /opt/scio/documents
 cp -r etc vendor /opt/scio
 ```
 
+Change ownership of documents to the user running scio:
+
+```bash
+chown -R scio /opt/scio/documents
+```
+
 ### To build
 
 ```bash

--- a/examples/systemd/scio-back.service
+++ b/examples/systemd/scio-back.service
@@ -3,7 +3,7 @@ Description=SCIO backend service
 [Service]
 User=scio
 LimitCORE=0
-ExecStart=/usr/bin/java -Xmx6G -jar /opt/scio/scio-back-latest-standalone.jar
+ExecStart=/usr/bin/java -Xmx6G -jar /opt/scio/scio-back-latest-standalone.jar -c /opt/scio/etc/scio.ini
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=scio

--- a/scripts/feeds/README.md
+++ b/scripts/feeds/README.md
@@ -17,7 +17,7 @@ makes it more intuitive what the ignore file does.
 ### Install requirements
 
 ```bash
-pip install requests justext urllib3 feedparser bs4
+pip install requests justext urllib3 feedparser bs4 python-magic
 ```
 
 ### Copy all scripts to /opt/scio_feeds
@@ -35,13 +35,13 @@ chown -R scio /opt/auto_report_download /opt/scio_feeds
 Feeds
 
 ```bash
-0 * * * * * /opt/scio_feeds/run-feeds.sh
+0 * * * * /opt/scio_feeds/run-feeds.sh
 ```
 
 Report repositories (optionally)
 
 ```bash
-0 5 * * * * /opt/scio_feeds/run-reports.sh
+0 5 * * * /opt/scio_feeds/run-reports.sh
 ```
 
 ## Add feed
@@ -57,5 +57,3 @@ Add a line to feeds.txt starting with 'p' (for partial), then a space and then t
 ### Ignore a file from download
 
 Add the full path of the file to ignore.txt
-
-

--- a/scripts/feeds/run-feeds.sh
+++ b/scripts/feeds/run-feeds.sh
@@ -35,6 +35,6 @@ $BASE/upload.py \
 
 for dir in pdf doc xls csv xml; do
     for file_name in `$BASE/submitcache.py -c $BASE/submitcache.db -a $BASE/$dir` ; do
-        $SCIODIR/submit.py $SUBMIT $file_name
+        $BASE/submit.py $SUBMIT $file_name
     done
 done


### PR DESCRIPTION
Bugfix:
* scio_feeds: SCIODIR was referenced but did not exist

Documentation
* Remove extra '*' from cron (scio_feeds) 
* chown document-directory (scio-back)
* use /opt/scio/etc/scio.ini as config file in service file (same as API) 