### PR TITLE
Add missing [Unit]

### DIFF
--- a/examples/systemd/scio-back.service
+++ b/examples/systemd/scio-back.service
@@ -1,3 +1,4 @@
+[Unit]
 Description=SCIO backend service
 
 [Service]


### PR DESCRIPTION
Add [Unit] to the top of the service-file example, so systemd won't complain as much.